### PR TITLE
Fixes for Paging and Sorting

### DIFF
--- a/partials/stats-all-episodes-pagination.php
+++ b/partials/stats-all-episodes-pagination.php
@@ -3,7 +3,6 @@
 		<span class="displaying-num"><?php echo $this->total_posts . ' ' . __( 'items', 'seriously-simple-stats' ) ?></span>
 		<span class='pagination-links'>
 		<?php if ( $pagenum != 1 ) { ?>
-			<!-- updated anchor tag to have the $prev_page_url -->
 			<a class="next-page" href="<?php echo $prev_page_url ?>">
 				<span class="screen-reader-text"><?php echo __( 'Previous page', 'seriously-simple-stats' ); ?></span>
 				<span aria-hidden="true">«</span>

--- a/partials/stats-all-episodes-pagination.php
+++ b/partials/stats-all-episodes-pagination.php
@@ -3,7 +3,8 @@
 		<span class="displaying-num"><?php echo $this->total_posts . ' ' . __( 'items', 'seriously-simple-stats' ) ?></span>
 		<span class='pagination-links'>
 		<?php if ( $pagenum != 1 ) { ?>
-			<a class="next-page" href="<?php echo $next_page_url ?>">
+			<!-- updated anchor tag to have the $prev_page_url -->
+			<a class="next-page" href="<?php echo $prev_page_url ?>">
 				<span class="screen-reader-text"><?php echo __( 'Previous page', 'seriously-simple-stats' ); ?></span>
 				<span aria-hidden="true">«</span>
 			</a>

--- a/partials/stats-all-episodes.php
+++ b/partials/stats-all-episodes.php
@@ -36,7 +36,7 @@
 			</thead>
 			<?php foreach ( $all_episodes_stats as $episode ) { ?>
 				<tr>
-					<td><?php echo $episode['date']; ?></td>
+					<td><?php echo $episode['formatted_date']; ?></td>
 					<td style="width: 50%;"><a href='<?php echo $episode['slug']; ?>'><?php echo $episode['episode_name']; ?></a></td>
 					<?php foreach ( $this->dates as $date ) { ?>
 							<td style='text-align: center;'><?php echo $episode[$date]; ?></td>

--- a/php/classes/class-all-episode-stats.php
+++ b/php/classes/class-all-episode-stats.php
@@ -129,6 +129,7 @@ class All_Episode_Stats {
 				'date'         => date( 'Y-m-d', strtotime( $post->post_date ) ), 
 				'slug'         => admin_url( 'post.php?post=' . $post->ID . '&action=edit' ),
 				'listens'      => $lifetime_count,
+				'formatted_date'  => date_i18n( get_option('date_format'), strtotime( $post->post_date ) ), 
 			);
 
 			foreach ( $this->dates as $date_key => $date ) {

--- a/php/classes/class-all-episode-stats.php
+++ b/php/classes/class-all-episode-stats.php
@@ -73,10 +73,8 @@ class All_Episode_Stats {
 			$order_by      = isset( $_GET['orderby'] ) ? '&orderby=' . sanitize_text_field( $_GET['orderby'] ) : "";
 			$order         = isset( $_GET['order'] ) ? '&order=' . sanitize_text_field( $_GET['order'] ) : "";
 			$prev_page     = ( $pagenum <= 1 ) ? 1 : $pagenum - 1;
-			// added $previous_page_url here 
 			$prev_page_url = admin_url( "edit.php?post_type=podcast&page=podcast_stats" . $order_by . $order . "&pagenum=" . $prev_page . "#last-three-months-container" );
 			$next_page     = $pagenum + 1;
-			// updated $next_page_url to have the $ext_page variable 
 			$next_page_url = admin_url( "edit.php?post_type=podcast&page=podcast_stats" . $order_by . $order . "&pagenum=" . $next_page . "#last-three-months-container" );
 			ob_start();
 			require_once SSP_STATS_DIR_PATH . 'partials/stats-all-episodes-pagination.php';
@@ -95,7 +93,6 @@ class All_Episode_Stats {
 		global $wpdb;
 		$date_keys = array_keys( $this->dates );
 
-		// updated default sort order to be date desc
 		$order_by = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : 'date';
 		$order    = isset( $_GET['order'] ) ? sanitize_text_field( $_GET['order'] ) : 'desc';
 
@@ -129,7 +126,6 @@ class All_Episode_Stats {
 
 			$episode_stats = array(
 				'episode_name' => $post->post_title,
-				// updated date format here to fix sort order 
 				'date'         => date( 'Y-m-d', strtotime( $post->post_date ) ), 
 				'slug'         => admin_url( 'post.php?post=' . $post->ID . '&action=edit' ),
 				'listens'      => $lifetime_count,

--- a/php/classes/class-all-episode-stats.php
+++ b/php/classes/class-all-episode-stats.php
@@ -70,11 +70,14 @@ class All_Episode_Stats {
 				$pagenum = 1;
 			}
 			$total_pages   = ceil( $this->total_posts / $this->total_per_page );
-			$prev_page     = ( $pagenum <= 1 ) ? 1 : $pagenum - 1;
 			$order_by      = isset( $_GET['orderby'] ) ? '&orderby=' . sanitize_text_field( $_GET['orderby'] ) : "";
 			$order         = isset( $_GET['order'] ) ? '&order=' . sanitize_text_field( $_GET['order'] ) : "";
-			$next_page_url = admin_url( "edit.php?post_type=podcast&page=podcast_stats" . $order_by . $order . "&pagenum=" . $prev_page . "#last-three-months-container" );
+			$prev_page     = ( $pagenum <= 1 ) ? 1 : $pagenum - 1;
+			// added $previous_page_url here 
+			$prev_page_url = admin_url( "edit.php?post_type=podcast&page=podcast_stats" . $order_by . $order . "&pagenum=" . $prev_page . "#last-three-months-container" );
 			$next_page     = $pagenum + 1;
+			// updated $next_page_url to have the $ext_page variable 
+			$next_page_url = admin_url( "edit.php?post_type=podcast&page=podcast_stats" . $order_by . $order . "&pagenum=" . $next_page . "#last-three-months-container" );
 			ob_start();
 			require_once SSP_STATS_DIR_PATH . 'partials/stats-all-episodes-pagination.php';
 			$html .= ob_get_clean();
@@ -92,7 +95,8 @@ class All_Episode_Stats {
 		global $wpdb;
 		$date_keys = array_keys( $this->dates );
 
-		$order_by = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : 'episode_name';
+		// updated default sort order to be date desc
+		$order_by = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : 'date';
 		$order    = isset( $_GET['order'] ) ? sanitize_text_field( $_GET['order'] ) : 'desc';
 
 		$all_episodes_stats = array();
@@ -125,7 +129,8 @@ class All_Episode_Stats {
 
 			$episode_stats = array(
 				'episode_name' => $post->post_title,
-				'date'         => date( 'm-d-Y', strtotime( $post->post_date ) ),
+				// updated date format here to fix sort order 
+				'date'         => date( 'Y-m-d', strtotime( $post->post_date ) ), 
 				'slug'         => admin_url( 'post.php?post=' . $post->ID . '&action=edit' ),
 				'listens'      => $lifetime_count,
 			);


### PR DESCRIPTION
Added update to fix issues with sorting and paging on the all stats page. Also made sort by date descending the default, as that how WordPress defaults it on their page. 