### PR TITLE
Fix: Only load the chart data on the stats and dashboard pages, fixes…

### DIFF
--- a/php/classes/class-ssp-stats.php
+++ b/php/classes/class-ssp-stats.php
@@ -729,12 +729,20 @@ class Stats {
 	 */
 	public function chart_data ( ) {
 
-		$output = '';
+		$current_screen = get_current_screen();
 
-		$output .= $this->daily_listens_chart();
-		$output .= $this->referrers_chart();
+		if( $current_screen == null ) return;
 
-		echo $output;
+		if( $current_screen->id == 'dashboard' || $current_screen->id == 'podcast_page_podcast_stats' ) {
+
+			$output = '';
+
+			$output .= $this->daily_listens_chart();
+			$output .= $this->referrers_chart();
+
+			echo $output;
+
+		}
 	}
 
 	/**


### PR DESCRIPTION
Only load the chart data on the stats and dashboard pages, fixes Google charts js error on other pages.

Fixes: #53